### PR TITLE
Move the ports output to JSON

### DIFF
--- a/src/info.h
+++ b/src/info.h
@@ -7,6 +7,8 @@
 
 #include <clap/clap.h>
 
+#include "json/json.h"
+
 namespace clap_info_host
 {
 
@@ -19,7 +21,7 @@ void recurseAndListCLAPSearchpath(ScanLevel l);
 
 
 void showParams(const clap_plugin *);
-void showAudioPorts(const clap_plugin *);
-void showNotePorts(const clap_plugin *);
+Json::Value showAudioPorts(const clap_plugin *);
+Json::Value showNotePorts(const clap_plugin *);
 }
 #endif // CLAP_INFO_INFO_TYPES_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -159,6 +159,9 @@ int main(int argc, char **argv)
     inst->init(inst);
     inst->activate(inst, 48000, 32, 4096);
 
+    Json::Value root;
+    Json::Value extensions;
+
     if (paramShow)
     {
         clap_info_host::showParams(inst);
@@ -166,13 +169,19 @@ int main(int argc, char **argv)
 
     if (audioPorts)
     {
-        clap_info_host::showAudioPorts(inst);
+        extensions[CLAP_EXT_AUDIO_PORTS] = clap_info_host::showAudioPorts(inst);
     }
 
     if (notePorts)
     {
-        clap_info_host::showNotePorts(inst);
+        extensions[CLAP_EXT_NOTE_PORTS] = clap_info_host::showNotePorts(inst);
     }
+
+    root["extensions"] = extensions;
+
+    Json::StyledWriter writer;
+    std::string out_string = writer.write(root);
+    std::cout << out_string << std::endl;
 
     inst->deactivate(inst);
     inst->destroy(inst);


### PR DESCRIPTION
Reworking the port details into JSON, which now means the main output looks a bit odd, but shows opens the door to full JSON conversion.

Structure is building upon extensions and modularity, and trying to stick to JSON idioms whilst also embodying the API structure of CLAP.