### PR TITLE
Moved most remaining data to JSON.

### DIFF
--- a/src/info.h
+++ b/src/info.h
@@ -20,7 +20,7 @@ enum ScanLevel {
 void recurseAndListCLAPSearchpath(ScanLevel l);
 
 
-void showParams(const clap_plugin *);
+Json::Value showParams(const clap_plugin *);
 Json::Value showAudioPorts(const clap_plugin *);
 Json::Value showNotePorts(const clap_plugin *);
 }

--- a/src/resolve_entrypoint.cpp
+++ b/src/resolve_entrypoint.cpp
@@ -50,7 +50,7 @@ clap_plugin_entry_t *entryFromClapPath(const std::filesystem::path &p)
     if (!han)
         return nullptr;
     auto phan = GetProcAddress(han, "clap_entry");
-    std::cout << "phan is " << phan << std::endl;
+//    std::cout << "phan is " << phan << std::endl;
     return (clap_plugin_entry_t *)phan;
 }
 #endif


### PR DESCRIPTION
As per discussion, there's likely rework to be done including perhaps a fresh look at the hierarchy/structure and whether:
The command-line options still make sense
All plugins should be included by default
Descriptor information from the factory should be nested within the plugin

For the moment, this provides a pure (in most cases) JSON output and so is consistent for processing.

Structure still subject to change and so not for production use yet.