### PR TITLE
Automatically build and publish cross-platform binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,8 @@ jobs:
           - os: windows-latest
             name: win
             dir_build: ./build/Release
-            file_name: clap-info.exe
+            file_name: clap-info
+            file_ext: .exe
     steps:
       - name: Install Windows dependencies
         if: matrix.os == 'windows-latest'
@@ -64,7 +65,7 @@ jobs:
       - name: Compress binary
         run: |
           cd "${{ matrix.dir_build }}"
-          zip ${{ matrix.file_name }}-${{ matrix.name }}.zip ${{ matrix.file_name }}
+          zip ${{ matrix.file_name }}-${{ matrix.name }}.zip ${{ matrix.file_name }}${{ matrix.file_ext }}
 
       - name: Upload binary
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,13 +33,13 @@ jobs:
         include:
           - os: ubuntu-latest
             dir_build: ./build
-            file_name: clap_info
+            file_name: clap-info
           - os: macos-latest
             dir_build: ./build
-            file_name: clap_info
+            file_name: clap-info
           - os: windows-latest
             dir_build: ./build
-            file_name: clap_info
+            file_name: clap-info
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,81 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  create_release:
+    name: Create release
+    runs-on: ubuntu-latest
+    outputs:
+      upload_id: ${{ steps.draft_release.outputs.id }}
+      upload_url: ${{ steps.draft_release.outputs.upload_url }}
+    steps:
+      - name: Draft release
+        id: draft_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: true
+
+  build_release:
+    name: Build release
+    needs: create_release
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            dir_build: ./build
+            file_name: clap_info
+          - os: macos-latest
+            dir_build: ./build
+            file_name: clap_info
+          - dir_build: windows-latest
+            path: ./build
+            file_name: clap_info
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Build binary
+        run: |
+          cmake -Bbuild
+          cmake --build "${{ matrix.dir_build }}"
+
+      - name: List files
+        run: ls "${{ matrix.dir_build }}"
+
+      - name: Compress binary
+        run: |
+          cd "${{ inputs.dir_build }}"
+          zip ${{ inputs.file_name }}-${{ matrix.name }}.zip ${{ matrix.file_name }}
+
+      - name: Upload binary
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create_release.outputs.upload_url }}
+          asset_path: ${{ inputs.dir_build }}/${{ inputs.file_name }}-${{ matrix.name }}.zip
+          asset_name: ${{ inputs.file_name }}-${{ matrix.name }}.zip
+          asset_content_type: application/zip
+
+  publish_release:
+    name: Publish release
+    needs: [create_release, build_release]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: eregon/publish-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        release_id: ${{ needs.create_release.outputs.upload_id }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Build binary
         run: |
-          cmake -S . -B ./build -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=“arm64;x86_64"
+          cmake -S . -B ./build -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
           cmake --build ./build --config Release
 
       - name: List files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Build binary
         run: |
-          cmake -S . -B ./build
+          cmake -S . -B ./build -DCMAKE_BUILD_TYPE=Release
           cmake --build ./build --config Release
 
       - name: List files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
             file_name: clap-info
           - os: windows-latest
             name: win
-            dir_build: ./build/x64/Debug/ALL_BUILD
+            dir_build: ./build/clap-info.dir
             file_name: clap-info
     steps:
       - name: Install Windows dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,8 @@ jobs:
           - os: macos-latest
             dir_build: ./build
             file_name: clap_info
-          - dir_build: windows-latest
-            path: ./build
+          - os: windows-latest
+            dir_build: ./build
             file_name: clap_info
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Release
 
 on:
+  pull_request:
+    branches:
+      - main
   push:
     tags:
       - "v*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,10 @@ jobs:
             dir_build: ./build
             file_name: clap-info
     steps:
+      - name: Install Windows dependencies
+        if: matrix.os == 'windows-latest'
+        run: choco install zip
+
       - name: Checkout code
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
             file_name: clap-info
           - os: windows-latest
             name: win
-            dir_build: ./build/x64
+            dir_build: ./build/x64/Debug
             file_name: clap-info
     steps:
       - name: Install Windows dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Build binary
         run: |
-          cmake -S . -B ./build -DCMAKE_BUILD_TYPE=Release
+          cmake -S . -B ./build -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=“arm64;x86_64"
           cmake --build ./build --config Release
 
       - name: List files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
             file_name: clap-info
           - os: windows-latest
             name: win
-            dir_build: ./build/x64/Debug
+            dir_build: ./build/x64/Debug/ALL_BUILD
             file_name: clap-info
     steps:
       - name: Install Windows dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,8 @@ jobs:
 
       - name: Compress binary
         run: |
-          cd "${{ inputs.dir_build }}"
-          zip ${{ inputs.file_name }}-${{ matrix.name }}.zip ${{ matrix.file_name }}
+          cd "${{ matrix.dir_build }}"
+          zip ${{ matrix.file_name }}-${{ matrix.name }}.zip ${{ matrix.file_name }}
 
       - name: Upload binary
         uses: actions/upload-release-asset@v1
@@ -65,8 +65,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.create_release.outputs.upload_url }}
-          asset_path: ${{ inputs.dir_build }}/${{ inputs.file_name }}-${{ matrix.name }}.zip
-          asset_name: ${{ inputs.file_name }}-${{ matrix.name }}.zip
+          asset_path: ${{ matrix.dir_build }}/${{ matrix.file_name }}-${{ matrix.name }}.zip
+          asset_name: ${{ matrix.file_name }}-${{ matrix.name }}.zip
           asset_content_type: application/zip
 
   publish_release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,12 +32,15 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           - os: ubuntu-latest
+            name: linux
             dir_build: ./build
             file_name: clap-info
           - os: macos-latest
+            name: mac
             dir_build: ./build
             file_name: clap-info
           - os: windows-latest
+            name: win
             dir_build: ./build
             file_name: clap-info
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Build binary
         run: |
-          cmake -S ./src -B "${{ matrix.dir_build }}"
+          cmake -S . -B "${{ matrix.dir_build }}"
           cmake --build "${{ matrix.dir_build }}" --config Release
 
       - name: List files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
             file_name: clap-info
           - os: windows-latest
             name: win
-            dir_build: ./build
+            dir_build: ./build/x64
             file_name: clap-info
     steps:
       - name: Install Windows dependencies
@@ -56,7 +56,7 @@ jobs:
       - name: Build binary
         run: |
           cmake -Bbuild
-          cmake --build "${{ matrix.dir_build }}"
+          cmake --build build
 
       - name: List files
         run: ls "${{ matrix.dir_build }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,8 +55,8 @@ jobs:
 
       - name: Build binary
         run: |
-          cmake -S . -B "${{ matrix.dir_build }}"
-          cmake --build "${{ matrix.dir_build }}" --config Release
+          cmake -S . -B ./build
+          cmake --build ./build --config Release
 
       - name: List files
         run: ls "${{ matrix.dir_build }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
             file_name: clap-info
           - os: windows-latest
             name: win
-            dir_build: ./build/clap-info.dir
+            dir_build: ./build/clap-info.dir/Debug
             file_name: clap-info
     steps:
       - name: Install Windows dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,8 @@ jobs:
             file_name: clap-info
           - os: windows-latest
             name: win
-            dir_build: ./build/clap-info.dir/Debug
-            file_name: clap-info
+            dir_build: ./build/Release
+            file_name: clap-info.exe
     steps:
       - name: Install Windows dependencies
         if: matrix.os == 'windows-latest'
@@ -55,8 +55,8 @@ jobs:
 
       - name: Build binary
         run: |
-          cmake -Bbuild
-          cmake --build build
+          cmake -S ./src -B "${{ matrix.dir_build }}"
+          cmake --build "${{ matrix.dir_build }}" --config Release
 
       - name: List files
         run: ls "${{ matrix.dir_build }}"


### PR DESCRIPTION
Fixes #11 

GitHub Action which is triggered whenever you create a git tag:
`git tag v1.0.0`

It will automatically build and publish binaries for Linux, Mac and Windows